### PR TITLE
Ansible galaxy requires these packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN yum makecache fast \
       sudo \
       which \
       initscripts \
+      python-urllib3 \
+      pyOpenSSL \
+      python2-ndg_httpsclient \
+      python-pyasn1 \
  && yum clean all
 
 # Disable requiretty.


### PR DESCRIPTION
- Ansible galaxy now uses SNI and breaks without these packages